### PR TITLE
Basic support for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,21 @@ objects.
 
 ### Supported Markdown Elements
 
-* All inline elements (italics, bold, strikethrough, inline code, hyperlinks)
-* Lists (ordered, unordered, checkboxes)
-* All headers
-* Code blocks
-* Block quotes (with some limitations)
-* Images
-* Thematic Breaks / Dividers
+- All inline elements (italics, bold, strikethrough, inline code, hyperlinks)
+- Lists (ordered, unordered, checkboxes)
+- All headers
+- Code blocks
+- Block quotes (with some limitations)
+- Images
+- Thematic Breaks / Dividers
+- Tables (alignment not preserved)
+
+### Not Yet Supported Markdown Elements
+
+- - Block quotes (limited functionality; does not support lists, headings, or images within the block quote)
 
 ## Installation
+
 ```
 npm install @instantish/mack
 ```
@@ -28,7 +34,6 @@ npm install @instantish/mack
 
 ```ts
 import {markdownToBlocks} from '@instantish/mack';
-
 
 const blocks = markdownToBlocks(`
 # Hello world
@@ -39,7 +44,7 @@ const blocks = markdownToBlocks(`
 abc _123_
 
 ![cat](https://images.unsplash.com/photo-1574158622682-e40e69881006)
-`)
+`);
 ```
 
 The `blocks` object now results in [this](https://app.slack.com/block-kit-builder/T01BFUV9UPJ#%7B%22blocks%22:%5B%7B%22text%22:%7B%22text%22:%22Hello%20world%22,%22type%22:%22plain_text%22%7D,%22type%22:%22header%22%7D,%7B%22text%22:%7B%22text%22:%22•%20bulleted%20item%201%5Cn•%20bulleted%20item%202%22,%22type%22:%22mrkdwn%22%7D,%22type%22:%22section%22%7D,%7B%22text%22:%7B%22text%22:%22abc%20_123_%22,%22type%22:%22mrkdwn%22%7D,%22type%22:%22section%22%7D,%7B%22alt_text%22:%22cat%22,%22image_url%22:%22https://images.unsplash.com/photo-1574158622682-e40e69881006?w=640%22,%22type%22:%22image%22%7D%5D%7D) payload.
@@ -47,8 +52,9 @@ The `blocks` object now results in [this](https://app.slack.com/block-kit-builde
 ## API
 
 `function markdownToBlocks(text: string, options: ParsingOptions): KnownBlock[]`
-* `text`: the content to parse
-* `options`: the options to use when parsing.
+
+- `text`: the content to parse
+- `options`: the options to use when parsing.
 
 ### Parsing Options
 

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -25,6 +25,11 @@ a **b** _c_ **_d_ e**
 
 - [ ] checkbox false
 - [x] checkbox true
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
 `;
 
     const actual = await markdownToBlocks(text);
@@ -45,6 +50,14 @@ a **b** _c_ **_d_ e**
       slack.section('• bullet _a_\n• bullet _b_'),
       slack.section('1. number _a_\n2. number _b_'),
       slack.section('• checkbox false\n• checkbox true'),
+      slack.section(
+        '```\n' +
+          '| Syntax | Description |\n' +
+          '| --- | --- |\n' +
+          '| Header | Title |\n' +
+          '| Paragraph | Text |\n' +
+          '```'
+      ),
     ];
 
     console.log(JSON.stringify(expected, null, 3));


### PR DESCRIPTION
Closes #2 

# Input
```markdown
| Syntax      | Description |
| ----------- | ----------- |
| Header      | Title       |
| Paragraph   | Text        |
```

# Output
A slack markdown block:
<img width="356" alt="Screen Shot 2021-10-18 at 5 56 29 PM" src="https://user-images.githubusercontent.com/1459660/137812276-96621619-5f45-4c75-a49f-a68b36717bc1.png">

# Out of scope
- Rendering links nicely
- Preserving the width of columns in the original table
- Preserving alignment from the original table
- Rendering images

Open to suggestions on better ways to do this!