### PR TITLE
Fix language in code block

### DIFF
--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -145,7 +145,7 @@ function parseCode(element: md.Code): SectionBlock {
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: `\`\`\`${element.lang}\n${element.value}\n\`\`\``,
+      text: `\`\`\`\n${element.value}\n\`\`\``,
     },
   };
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -64,4 +64,62 @@ a **b** _c_ **_d_ e**
 
     expect(actual).toStrictEqual(expected);
   });
+
+  describe('code blocks', () => {
+    it('should parse code blocks with no language', async () => {
+      const text = `\`\`\`
+if (a === 'hi') {
+  console.log('hi!')
+} else {
+  console.log('hello')
+}
+\`\`\``;
+
+      const actual = await markdownToBlocks(text);
+
+      const expected = [
+        slack.section(
+          `\`\`\`
+if (a === 'hi') {
+  console.log('hi!')
+} else {
+  console.log('hello')
+}
+\`\`\``
+        ),
+      ];
+
+      console.log(JSON.stringify(expected, null, 3));
+
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it('should parse code blocks with language', async () => {
+      const text = `\`\`\`javascript
+if (a === 'hi') {
+  console.log('hi!')
+} else {
+  console.log('hello')
+}
+\`\`\``;
+
+      const actual = await markdownToBlocks(text);
+
+      const expected = [
+        slack.section(
+          `\`\`\`
+if (a === 'hi') {
+  console.log('hi!')
+} else {
+  console.log('hello')
+}
+\`\`\``
+        ),
+      ];
+
+      console.log(JSON.stringify(expected, null, 3));
+
+      expect(actual).toStrictEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
Closes #4 

Tests:
- A code block with a language specified
- A code block without a language specified

Slack inline code blocks do not yet have syntax highlighting or language settings.