### PR TITLE
Truncate text that exceeds Slack API text limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Mack is a Markdown parser to convert any Markdown content to Slack BlockKit bloc
 uses [unified](https://github.com/unifiedjs/unified) to create a Markdown AST, then converts the AST into Slack
 objects.
 
+Text is truncated to fit within the Slack API's limits.
+
 ### Supported Markdown Elements
 
 - All inline elements (italics, bold, strikethrough, inline code, hyperlinks)

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -5,12 +5,17 @@ import type {
   SectionBlock,
 } from '@slack/types';
 
+const MAX_TEXT_LENGTH = 3000;
+const MAX_HEADER_LENGTH = 150;
+const MAX_IMAGE_TITLE_LENGTH = 2000;
+const MAX_IMAGE_ALT_TEXT_LENGTH = 2000;
+
 export function section(text: string): SectionBlock {
   return {
     type: 'section',
     text: {
       type: 'mrkdwn',
-      text: text,
+      text: text.slice(0, MAX_TEXT_LENGTH),
     },
   };
 }
@@ -26,7 +31,7 @@ export function header(text: string): HeaderBlock {
     type: 'header',
     text: {
       type: 'plain_text',
-      text: text,
+      text: text.slice(0, MAX_HEADER_LENGTH),
     },
   };
 }
@@ -39,11 +44,11 @@ export function image(
   return {
     type: 'image',
     image_url: url,
-    alt_text: altText,
+    alt_text: altText.slice(0, MAX_IMAGE_ALT_TEXT_LENGTH),
     title: title
       ? {
           type: 'plain_text',
-          text: title,
+          text: title.slice(0, MAX_IMAGE_TITLE_LENGTH),
         }
       : undefined,
   };

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -95,3 +95,38 @@ describe('parser', () => {
     expect(actual).toStrictEqual(expected);
   });
 });
+
+it('should truncate basic markdown', () => {
+  const a4000 = new Array(4000).fill('a').join('');
+  const a3000 = new Array(3000).fill('a').join('');
+  const node = md.root(md.paragraph(md.text(a4000)));
+
+  const actual = parseBlocks(node);
+
+  const expected = [slack.section(a3000)];
+
+  expect(actual.length).toStrictEqual(expected.length);
+});
+
+it('should truncate header', () => {
+  const a200 = new Array(200).fill('a').join('');
+  const a150 = new Array(150).fill('a').join('');
+  const node = md.root(md.heading(1, md.strong(md.text(a200))));
+  const actual = parseBlocks(node);
+
+  const expected = [slack.header(a150)];
+
+  expect(actual.length).toStrictEqual(expected.length);
+});
+
+it('should truncate image title', () => {
+  const a3000 = new Array(3000).fill('a').join('');
+  const a2000 = new Array(2000).fill('a').join('');
+  const node = md.root(md.paragraph(md.image('url', a3000)));
+
+  const actual = parseBlocks(node);
+
+  const expected = [slack.image('url', a2000)];
+
+  expect(actual.length).toStrictEqual(expected.length);
+});


### PR DESCRIPTION
Closes #6 

Unit tests included

Supports text in markdown sections, headers, and image fields.