### PR TITLE
Fix inline code with single quote escaped

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,10 @@
       "dependencies": {
         "@slack/types": "^2.1.0",
         "fast-xml-parser": "^4.0.6",
-        "marked": "^4.0.12"
+        "marked": "^9.1.2"
       },
       "devDependencies": {
         "@types/jest": "^26.0.23",
-        "@types/marked": "^4.0.2",
         "@types/node": "^15.12.4",
         "gts": "^3.1.0",
         "jest": "^27.0.5",
@@ -1228,12 +1227,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/marked": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.2.tgz",
-      "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ==",
-      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
@@ -5152,14 +5145,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.2.tgz",
+      "integrity": "sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 16"
       }
     },
     "node_modules/meow": {
@@ -8457,12 +8450,6 @@
         "@types/node": "*"
       }
     },
-    "@types/marked": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.2.tgz",
-      "integrity": "sha512-auNrZ/c0w6wsM9DccwVxWHssrMDezHUAXNesdp2RQrCVCyrQbOiSq7yqdJKrUQQpw9VTm7CGYJH2A/YG7jjrjQ==",
-      "dev": true
-    },
     "@types/minimist": {
       "version": "1.2.1",
       "dev": true
@@ -10951,9 +10938,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.2.tgz",
+      "integrity": "sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w=="
     },
     "meow": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,10 @@
   "dependencies": {
     "@slack/types": "^2.1.0",
     "fast-xml-parser": "^4.0.6",
-    "marked": "^4.0.12"
+    "marked": "^9.1.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
-    "@types/marked": "^4.0.2",
     "@types/node": "^15.12.4",
     "gts": "^3.1.0",
     "jest": "^27.0.5",

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -65,7 +65,7 @@ function parseMrkdwn(
     }
 
     case 'codespan':
-      return `\`${element.text}\``;
+      return `${element.raw}`;
 
     case 'strong': {
       return `*${element.tokens
@@ -107,6 +107,7 @@ function parsePhrasingContentToStrings(
   if (element.type === 'image') {
     accumulator.push(element.href ?? element.title ?? element.text ?? 'image');
   } else {
+    if ('text' in element) console.log(element?.text);
     const text = parseMrkdwn(element);
     accumulator.push(text);
   }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -7,19 +7,19 @@ import {
 } from '@slack/types';
 import {ListOptions, ParsingOptions} from '../types';
 import {section, divider, header, image} from '../slack';
-import {marked} from 'marked';
+import {Token, Tokens, TokensList} from 'marked';
 import {XMLParser} from 'fast-xml-parser';
 
 type PhrasingToken =
-  | marked.Tokens.Link
-  | marked.Tokens.Em
-  | marked.Tokens.Strong
-  | marked.Tokens.Del
-  | marked.Tokens.Br
-  | marked.Tokens.Image
-  | marked.Tokens.Codespan
-  | marked.Tokens.Text
-  | marked.Tokens.HTML;
+  | Tokens.Link
+  | Tokens.Em
+  | Tokens.Strong
+  | Tokens.Del
+  | Tokens.Br
+  | Tokens.Image
+  | Tokens.Codespan
+  | Tokens.Text
+  | Tokens.HTML;
 
 function parsePlainText(element: PhrasingToken): string[] {
   switch (element.type) {
@@ -48,9 +48,7 @@ function isSectionBlock(block: KnownBlock): block is SectionBlock {
   return block.type === 'section';
 }
 
-function parseMrkdwn(
-  element: Exclude<PhrasingToken, marked.Tokens.Image>
-): string {
+function parseMrkdwn(element: Exclude<PhrasingToken, Tokens.Image>): string {
   switch (element.type) {
     case 'link': {
       return `<${element.href}|${element.tokens
@@ -120,7 +118,7 @@ function parsePhrasingContent(
     const imageBlock: ImageBlock = image(
       element.href,
       element.text || element.title || element.href,
-      element.title
+      element.title || ''
     );
     accumulator.push(imageBlock);
   } else {
@@ -129,39 +127,45 @@ function parsePhrasingContent(
   }
 }
 
-function parseParagraph(element: marked.Tokens.Paragraph): KnownBlock[] {
-  return element.tokens.reduce((accumulator, child) => {
-    parsePhrasingContent(child as PhrasingToken, accumulator);
-    return accumulator;
-  }, [] as (SectionBlock | ImageBlock)[]);
+function parseParagraph(
+  element: Tokens.Paragraph | Tokens.Generic
+): KnownBlock[] {
+  return element.tokens
+    ? element.tokens.reduce((accumulator, child) => {
+        parsePhrasingContent(child as PhrasingToken, accumulator);
+        return accumulator;
+      }, [] as (SectionBlock | ImageBlock)[])
+    : [];
 }
 
-function parseHeading(element: marked.Tokens.Heading): HeaderBlock {
-  return header(
-    element.tokens
-      .flatMap(child => parsePlainText(child as PhrasingToken))
-      .join('')
-  );
+function parseHeading(element: Tokens.Heading | Tokens.Generic): HeaderBlock {
+  return element.tokens
+    ? header(
+        element.tokens
+          .flatMap(child => parsePlainText(child as PhrasingToken))
+          .join('')
+      )
+    : header('');
 }
 
-function parseCode(element: marked.Tokens.Code): SectionBlock {
+function parseCode(element: Tokens.Code | Tokens.Generic): SectionBlock {
   return section(`\`\`\`\n${element.text}\n\`\`\``);
 }
 
 function parseList(
-  element: marked.Tokens.List,
+  element: Tokens.List | Tokens.Generic,
   options: ListOptions = {}
 ): SectionBlock {
   let index = 0;
-  const contents = element.items.map(item => {
-    const paragraph = item.tokens[0] as marked.Tokens.Text;
+  const contents = element.items.map((item: Tokens.ListItem) => {
+    const paragraph = item.tokens[0] as Tokens.Text;
     if (!paragraph || paragraph.type !== 'text' || !paragraph.tokens?.length) {
       return paragraph?.text || '';
     }
 
     const text = paragraph.tokens
       .filter(
-        (child): child is Exclude<PhrasingToken, marked.Tokens.Image> =>
+        (child): child is Exclude<PhrasingToken, Tokens.Image> =>
           child.type !== 'image'
       )
       .flatMap(parseMrkdwn)
@@ -184,7 +188,7 @@ function combineBetweenPipes(texts: String[]): string {
   return `| ${texts.join(' | ')} |`;
 }
 
-function parseTableRows(rows: marked.Tokens.TableCell[][]): string[] {
+function parseTableRows(rows: Tokens.TableCell[][]): string[] {
   const parsedRows: string[] = [];
   rows.forEach((row, index) => {
     const parsedCells = parseTableRow(row);
@@ -198,7 +202,7 @@ function parseTableRows(rows: marked.Tokens.TableCell[][]): string[] {
   return parsedRows;
 }
 
-function parseTableRow(row: marked.Tokens.TableCell[]): String[] {
+function parseTableRow(row: Tokens.TableCell[]): String[] {
   const parsedCells: String[] = [];
   row.forEach(cell => {
     parsedCells.push(parseTableCell(cell));
@@ -206,7 +210,7 @@ function parseTableRow(row: marked.Tokens.TableCell[]): String[] {
   return parsedCells;
 }
 
-function parseTableCell(cell: marked.Tokens.TableCell): String {
+function parseTableCell(cell: Tokens.TableCell): String {
   const texts = cell.tokens.reduce((accumulator, child) => {
     parsePhrasingContentToStrings(child as PhrasingToken, accumulator);
     return accumulator;
@@ -214,24 +218,28 @@ function parseTableCell(cell: marked.Tokens.TableCell): String {
   return texts.join(' ');
 }
 
-function parseTable(element: marked.Tokens.Table): SectionBlock {
+function parseTable(element: Tokens.Table | Tokens.Generic): SectionBlock {
   const parsedRows = parseTableRows([element.header, ...element.rows]);
 
   return section(`\`\`\`\n${parsedRows.join('\n')}\n\`\`\``);
 }
 
-function parseBlockquote(element: marked.Tokens.Blockquote): KnownBlock[] {
+function parseBlockquote(
+  element: Tokens.Blockquote | Tokens.Generic
+): KnownBlock[] {
   return element.tokens
-    .filter(
-      (child): child is marked.Tokens.Paragraph => child.type === 'paragraph'
-    )
-    .flatMap(p =>
-      parseParagraph(p).map(block => {
-        if (isSectionBlock(block) && block.text?.text?.includes('\n'))
-          block.text.text = '> ' + block.text.text.replace(/\n/g, '\n> ');
-        return block;
-      })
-    );
+    ? element.tokens
+        .filter(
+          (child): child is Tokens.Paragraph => child.type === 'paragraph'
+        )
+        .flatMap(p =>
+          parseParagraph(p).map(block => {
+            if (isSectionBlock(block) && block.text?.text?.includes('\n'))
+              block.text.text = '> ' + block.text.text.replace(/\n/g, '\n> ');
+            return block;
+          })
+        )
+    : [];
 }
 
 function parseThematicBreak(): DividerBlock {
@@ -239,7 +247,7 @@ function parseThematicBreak(): DividerBlock {
 }
 
 function parseHTML(
-  element: marked.Tokens.HTML | marked.Tokens.Tag
+  element: Tokens.HTML | Tokens.Tag | Tokens.Generic
 ): KnownBlock[] {
   const parser = new XMLParser({ignoreAttributes: false});
   const res = parser.parse(element.raw);
@@ -256,10 +264,7 @@ function parseHTML(
   } else return [];
 }
 
-function parseToken(
-  token: marked.Token,
-  options: ParsingOptions
-): KnownBlock[] {
+function parseToken(token: Token, options: ParsingOptions): KnownBlock[] {
   switch (token.type) {
     case 'heading':
       return [parseHeading(token)];
@@ -291,8 +296,11 @@ function parseToken(
 }
 
 export function parseBlocks(
-  tokens: marked.TokensList,
+  tokens: TokensList,
   options: ParsingOptions = {}
 ): KnownBlock[] {
-  return tokens.flatMap(token => parseToken(token, options));
+  return tokens.flatMap(token => {
+    const parsed = parseToken(token, options);
+    return parsed;
+  });
 }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -107,7 +107,6 @@ function parsePhrasingContentToStrings(
   if (element.type === 'image') {
     accumulator.push(element.href ?? element.title ?? element.text ?? 'image');
   } else {
-    if ('text' in element) console.log(element?.text);
     const text = parseMrkdwn(element);
     accumulator.push(text);
   }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -132,4 +132,11 @@ if (a === 'hi') {
     const expected = [slack.section('&lt;&gt;&amp;\'""\'&amp;&gt;&lt;')];
     expect(actual).toStrictEqual(expected);
   });
+
+  it('should correctly parse inline code with single quotes', async () => {
+    const text = "`'YOUR_API_KEY'`";
+    const actual = await markdownToBlocks(text);
+    const expected = [slack.section("`'YOUR_API_KEY'`")];
+    expect(actual).toStrictEqual(expected);
+  });
 });


### PR DESCRIPTION
When inline code contains single quote it renders the single quote as `&#39;`

For example for const text = "`'YOUR_API_KEY'`"  it renders` &#39;YOUR_API_KEY&#39; `
